### PR TITLE
Automatically copy UK TRE code of conduct when website is built

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -45,6 +45,13 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
 
+      - name: Copy UK TRE code of conduct
+        run: |
+          cp content/about/code_of_conduct.template content/about/code_of_conduct.md
+          curl -sfSL \
+            https://raw.githubusercontent.com/uk-tre/.github/main/CODE_OF_CONDUCT.md >> \
+            content/about/code_of_conduct.md
+
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ public
 node_modules
 resources
 .hugo_build.lock
+
+content/about/code_of_conduct.md

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -50,6 +50,7 @@ footer:
   weight: 90
 
 - name: Code of conduct
+  pageref: /about/code_of_conduct
   weight: 90
 
 

--- a/content/about/code_of_conduct.template
+++ b/content/about/code_of_conduct.template
@@ -1,0 +1,9 @@
+---
+title: "Code of Conduct"
+description: "The UK TRE code of conduct"
+---
+
+<!--
+This is a placeholder for the UK TRE Code of Conduct.
+It will be automatically copied from https://github.com/uk-tre/.github/blob/main/CODE_OF_CONDUCT.md when the website is built on GitHub Pages.
+-->


### PR DESCRIPTION
This will automatically copy https://github.com/uk-tre/.github/blob/main/CODE_OF_CONDUCT.md when the website is published to GitHub pages

Closes https://github.com/uk-tre/community-management/issues/10

Preview: https://www.manicstreetpreacher.co.uk/uktre-hugo-website/